### PR TITLE
changed self.instance to self in send_location

### DIFF
--- a/whatsapp/ext/_send_media.py
+++ b/whatsapp/ext/_send_media.py
@@ -19,15 +19,15 @@ def send_location(self, lat: str, long: str, name: str, address: str, recipient_
         >>> whatsapp.send_location("-23.564", "-46.654", "My Location", "Rua dois, 123", "5511999999999")
     """
     try:
-        sender = dict(self.instance.l)[sender]
+        sender = dict(self.l)[sender]
         
         
 
     except:
-        sender = self.instance.phone_number_id
+        sender = self.phone_number_id
         
     if sender == None:
-        sender = self.instance.phone_number_id
+        sender = self.phone_number_id
 
     url = f"https://graph.facebook.com/v18.0/{sender}/messages"
     data = {


### PR DESCRIPTION
All other attachement sending methods get the phone_number_id and other attributes from self except send_location which is getting it from self.instance resulting in an closed issue: [BUG] 'WhatsApp' object has no attribute 'instance'. Closes #24 